### PR TITLE
fix: ensure filename is 🥺 before doing anything

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,11 @@ use std::{env, io, os::unix::process::CommandExt, process::Command};
 use syslog::{unix, Facility::LOG_AUTH, Formatter3164};
 
 fn main() -> io::Result<()> {
+    if env::args().nth(0).unwrap() != "🥺" {
+        eprintln!("error: called 🥺 with name {}", env::args().nth(0).unwrap());
+        return Ok(());
+    }
+
     if env::args().len() == 1 {
         eprintln!("usage: {} <command> [args]", env::args().nth(0).unwrap());
         return Ok(());


### PR DESCRIPTION
Fixes a potential security vulnerability if 🥺 is renamed to an ASCII file name via user error or external exploit. The `syslog` call should have already broke it if it wasn't installed, but this should prevent usages of 🥺 if it was *copied* to a file with an ASCII file name as well.