### PR TITLE
Fix crash when calling a command with a name like rÿd

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,21 @@
 #![allow(non_snake_case)]
 
-use std::{env, io, os::unix::process::CommandExt, process::Command};
+use std::{env, io, os::unix::process::CommandExt, process::Command, ffi::OsString};
 use syslog::{unix, Facility::LOG_AUTH, Formatter3164};
 
 fn main() -> io::Result<()> {
-    if env::args().nth(0).unwrap() != "🥺" {
+    if env::args_os().nth(0).unwrap() != "🥺" {
         eprintln!("error: called 🥺 with name {}", env::args().nth(0).unwrap());
         return Ok(());
     }
 
-    if env::args().len() == 1 {
+    if env::args_os().len() == 1 {
         eprintln!("usage: {} <command> [args]", env::args().nth(0).unwrap());
         return Ok(());
     }
 
-    let program = env::args().nth(1).unwrap();
-    let args = env::args().skip(2).collect::<Vec<String>>();
+    let program = env::args_os().nth(1).unwrap();
+    let args = env::args_os().skip(2).collect::<Vec<OsString>>();
     let mut writer = unix(Formatter3164 {
         facility: LOG_AUTH,
         hostname: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,12 @@ use syslog::{unix, Facility::LOG_AUTH, Formatter3164};
 
 fn main() -> io::Result<()> {
     if env::args_os().nth(0).unwrap() != "🥺" {
-        eprintln!("error: called 🥺 with name {}", env::args().nth(0).unwrap());
+        eprintln!("error: called 🥺 with name {:?}", env::args_os().nth(0).unwrap());
         return Ok(());
     }
 
     if env::args_os().len() == 1 {
-        eprintln!("usage: {} <command> [args]", env::args().nth(0).unwrap());
+        eprintln!("usage: {:?} <command> [args]", env::args_os().nth(0).unwrap());
         return Ok(());
     }
 


### PR DESCRIPTION
🥺 currently crashes when you try to use a command that has a non-utf-8 compatible name, e.g. one with a \377 byte in it.
```
$ 🥺 ~/bin/r$'\377'd
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: "/home/oren/bin/r\xFFd"', library/std/src/env.rs:805:51
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
This is due to using String for arguments instead of OsString. (And args() instead of args_os()).
